### PR TITLE
Fixed Spacing and sizing of the social media images

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -102,8 +102,8 @@ p {
 
 .social img {
     padding: 15px;
-    max-width: 300px;
-    max-height:300px;
+    max-width: 150px;
+    max-height:150px;
 }
   
 .social img:hover {

--- a/css/style.css
+++ b/css/style.css
@@ -102,6 +102,8 @@ p {
 
 .social img {
     padding: 15px;
+    max-width: 300px;
+    max-height:300px;
 }
   
 .social img:hover {


### PR DESCRIPTION
Hey Art,

this pull request fixes the spacings on the icons in the hacknight page, 

Before:
<img width="1440" alt="Screen Shot 2019-10-16 at 7 25 45 PM" src="https://user-images.githubusercontent.com/1953943/66981191-dce7fe80-f067-11e9-8c93-566594c33acf.png">


After
<img width="1009" alt="Screen Shot 2019-10-16 at 10 52 26 PM" src="https://user-images.githubusercontent.com/1953943/66981167-cd68b580-f067-11e9-95e2-d102b8ac414e.png">
